### PR TITLE
Specify the character encoding using  `<meta charset="utf-8">`

### DIFF
--- a/app/views/layouts/default.swig
+++ b/app/views/layouts/default.swig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ __("en-US") }}" class="{{ __("en-US") }}">
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta charset="utf-8">
     <meta http-equiv="content-language" content="{{ __("en-US") }}"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Use the shorter `<meta charset="utf-8">` to specify the character encoding instead of the longer `<meta http-equiv="content-type" content="text/html; charset=utf-8"/>`.

For more in-depth information about how the character encoding of HTML documents is determined, please see: http://blog.whatwg.org/the-road-to-html-5-character-encoding.
